### PR TITLE
Fixed annoying 1-pixel gap between active menu item decoration

### DIFF
--- a/css/robosane.css
+++ b/css/robosane.css
@@ -418,7 +418,7 @@ li.active.current:before {
   top: 0;
   left: 0;
   height: 110%;
-  width: 50%;
+  width: 51%;
   background: #ed2024;
   -webkit-transform: skew(0deg, 20deg);
   -moz-transform: skew(0deg, 20deg);


### PR DESCRIPTION
Sometimes there would be a one pixel gap in the navbar decoration.  This patch fixes that.
